### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Summary** 
 
-Squirrelly is a modern, configurable, and blazing fast template engine implemented in JavaScript. It works out of the box with ExpressJS and has a small footprint.
+Squirrelly is a modern, configurable, and blazing fast template engine implemented in JavaScript. It works out of the box with ExpressJS and weighs only **2.5KB gzipped**.
 
 ## Why Squirrelly?
 


### PR DESCRIPTION
Modified summary per instructions. No line after "Squirrelly is licensed under the MIT license."