### PR TITLE
Added explanation for helper ref '../' test

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -125,7 +125,7 @@ function Compile (str) {
     function helperRef (name, id, filters) {
       var prefix
       if (typeof id !== 'undefined') {
-        if (/(?:\.\.\/)+/g.test(id)) {
+        if (/(?:\.\.\/)+/g.test(id)) { // Test if the helper reference is prefixed with ../
           prefix = helperArray[helperNumber - (id.length / 3) - 1].id
         } else {
           prefix = id.slice(0, -1)


### PR DESCRIPTION
Check **all** applicable boxes below (put an **x** in between the square brackets, with no spaces)

- [x ] This is to fix an issue. **Issue #**:
- [x] If I modified anything other than comments, I ran `npm run build` and `npm test`

## Summary
This pull request makes it so...
